### PR TITLE
Add inline comment to explain alternative key assignment

### DIFF
--- a/Dictionary tutorial Euro Python 2025.ipynb
+++ b/Dictionary tutorial Euro Python 2025.ipynb
@@ -1382,6 +1382,8 @@
     "        self.data = [None] * 8\n",
     "\n",
     "        for key, value in list_of_pairs:\n",
+    "            # We can use the assignment `self[key]` to invoke the `__setitem__` method\n",
+    "            # which contains all logic to store the key-value pair in `self.data`.\n",
     "            self[key] = value\n",
     "\n",
     "    def key_location(self, key, data_to_use = None):\n",


### PR DESCRIPTION
## Scope
I wasn't able to view this tutorial live, but was working through the Jupyter notebook and was a bit confused on why we used one assignment in the `HashTable` class in some examples and a different assignment in the following examples. Until I got the crux of the assignment (which invokes the `__setitem__` method of course).

To help others who might be struggling, I've added an inline comment which might clarify some things off the bat.